### PR TITLE
refactor(server/web): remove redundant nil check (#5420)

### DIFF
--- a/server/web/controller.go
+++ b/server/web/controller.go
@@ -312,19 +312,17 @@ func (c *Controller) RenderBytes() ([]byte, error) {
 	if err == nil && c.Layout != "" {
 		c.Data["LayoutContent"] = template.HTML(buf.String())
 
-		if c.LayoutSections != nil {
-			for sectionName, sectionTpl := range c.LayoutSections {
-				if sectionTpl == "" {
-					c.Data[sectionName] = ""
-					continue
-				}
-				buf.Reset()
-				err = ExecuteViewPathTemplate(&buf, sectionTpl, c.viewPath(), c.Data)
-				if err != nil {
-					return nil, err
-				}
-				c.Data[sectionName] = template.HTML(buf.String())
+		for sectionName, sectionTpl := range c.LayoutSections {
+			if sectionTpl == "" {
+				c.Data[sectionName] = ""
+				continue
 			}
+			buf.Reset()
+			err = ExecuteViewPathTemplate(&buf, sectionTpl, c.viewPath(), c.Data)
+			if err != nil {
+				return nil, err
+			}
+			c.Data[sectionName] = template.HTML(buf.String())
 		}
 
 		buf.Reset()
@@ -345,13 +343,11 @@ func (c *Controller) renderTemplate() (bytes.Buffer, error) {
 		buildFiles := []string{c.TplName}
 		if c.Layout != "" {
 			buildFiles = append(buildFiles, c.Layout)
-			if c.LayoutSections != nil {
-				for _, sectionTpl := range c.LayoutSections {
-					if sectionTpl == "" {
-						continue
-					}
-					buildFiles = append(buildFiles, sectionTpl)
+			for _, sectionTpl := range c.LayoutSections {
+				if sectionTpl == "" {
+					continue
 				}
+				buildFiles = append(buildFiles, sectionTpl)
 			}
 		}
 		BuildTemplate(c.viewPath(), buildFiles...)

--- a/server/web/router.go
+++ b/server/web/router.go
@@ -1357,19 +1357,15 @@ func (p *ControllerRegister) GetAllControllerInfo() (routerInfos []*ControllerIn
 }
 
 func composeControllerInfos(tree *Tree, routerInfos *[]*ControllerInfo) {
-	if tree.fixrouters != nil {
-		for _, subTree := range tree.fixrouters {
-			composeControllerInfos(subTree, routerInfos)
-		}
+	for _, subTree := range tree.fixrouters {
+		composeControllerInfos(subTree, routerInfos)
 	}
 	if tree.wildcard != nil {
 		composeControllerInfos(tree.wildcard, routerInfos)
 	}
-	if tree.leaves != nil {
-		for _, l := range tree.leaves {
-			if c, ok := l.runObject.(*ControllerInfo); ok {
-				*routerInfos = append(*routerInfos, c)
-			}
+	for _, l := range tree.leaves {
+		if c, ok := l.runObject.(*ControllerInfo); ok {
+			*routerInfos = append(*routerInfos, c)
 		}
 	}
 }


### PR DESCRIPTION
From the Go specification [1]:

  "1. For a nil slice, the number of iterations is 0."
  "3. If the map is nil, the number of iterations is 0."

Therefore, an additional nil check for before the loop is unnecessary.

[1]: https://go.dev/ref/spec#For_range

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved rendering logic for content display and template execution.
	- Enhanced routing control flow for better navigation and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->